### PR TITLE
1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ About jupyterhub-feedstock
 
 Home: https://github.com/jupyterhub/jupyterhub
 
-Package license: BSD 3-Clause
+Package license: BSD-3-Clause
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/jupyterhub-feedstock/blob/master/LICENSE.txt)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.2.2" %}
+{% set version = "1.3.0" %}
 
 package:
   name: jupyterhub-feedstock
@@ -7,11 +7,11 @@ package:
 source:
   fn: jupyterhub-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/j/jupyterhub/jupyterhub-{{ version }}.tar.gz
-  sha256: 634e64ab9cf14e73cfc1d5838d595febdaf957607eb907b43f29af345c05b87e
+  sha256: 05ff701209c340c792cd103606c448c52ace772ece858380905ddd1a2136ee8e
 
 build:
   number: 0
-  skip: true  # [py<35]
+  skip: true  # [py<36]
 
 requirements:
   host:
@@ -33,11 +33,11 @@ outputs:
         - async_generator >=1.9
         - certipy >=0.1.2
         - entrypoints
-        - jinja2
+        - jinja2 >=2.11.0
         - jupyter_telemetry >=0.1.0
         - oauthlib >=3.0
         - pamela  # [not win]
-        - prometheus_client >=0.0.21
+        - prometheus_client >=0.4.0
         - psutil  # [win]
         - pycurl
         - python-dateutil


### PR DESCRIPTION
bumps requirements, including python to >-3.6