### PR TITLE
configurable-http-proxy >= 4

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @blink1073 @consideRatio @minrk
+* @blink1073 @consideRatio @manics @minrk

--- a/README.md
+++ b/README.md
@@ -340,5 +340,6 @@ Feedstock Maintainers
 
 * [@blink1073](https://github.com/blink1073/)
 * [@consideRatio](https://github.com/consideRatio/)
+* [@manics](https://github.com/manics/)
 * [@minrk](https://github.com/minrk/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -77,7 +77,7 @@ outputs:
       run:
         - python
         - {{ pin_subpackage("jupyterhub-base", exact=True) }}
-        - configurable-http-proxy
+        - configurable-http-proxy >= 4
         - nodejs >=12
     test:
       imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -77,7 +77,7 @@ outputs:
       run:
         - python
         - {{ pin_subpackage("jupyterhub-base", exact=True) }}
-        - configurable-http-proxy >= 4
+        - configurable-http-proxy >=4
         - nodejs >=12
     test:
       imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -97,3 +97,4 @@ extra:
     - minrk
     - blink1073
     - consideRatio
+    - manics

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 05ff701209c340c792cd103606c448c52ace772ece858380905ddd1a2136ee8e
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<36]
 
 requirements:


### PR DESCRIPTION
Recent conda-forge builds of configurable-http-proxy are tied to a node version. If a new node version without a corresponding configurable-http-proxy build is installed the resolver may pick an ancient version of configurable-http-proxy (e.g. 1.3.0) that doesn't specify the required node version. Adding a minimum here should mean the node version is downgraded to one for which a configurable-http-proxy build is available.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
