### PR TITLE
move psutil and pycurl out of base

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -12,6 +12,7 @@ jobs:
         CONFIG: linux_64_
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        SHORT_CONFIG: linux_64_
   timeoutInMinutes: 360
 
   steps:
@@ -43,3 +44,32 @@ jobs:
       BINSTAR_TOKEN: $(BINSTAR_TOKEN)
       FEEDSTOCK_TOKEN: $(FEEDSTOCK_TOKEN)
       STAGING_BINSTAR_TOKEN: $(STAGING_BINSTAR_TOKEN)
+  - script: |
+        export CI=azure
+        export CI_RUN_ID=$(build.BuildNumber).$(system.JobAttempt)
+        export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})
+        export CONDA_BLD_DIR=build_artifacts
+        export ARTIFACT_STAGING_DIR="$(Build.ArtifactStagingDirectory)"
+        # Archive everything in CONDA_BLD_DIR except environments
+        export BLD_ARTIFACT_PREFIX=conda_artifacts
+        if [[ "$AGENT_JOBSTATUS" == "Failed" ]]; then
+          # Archive the CONDA_BLD_DIR environments only when the job fails
+          export ENV_ARTIFACT_PREFIX=conda_envs
+        fi
+        ./.scripts/create_conda_build_artifacts.sh
+    displayName: Prepare conda build artifacts
+    condition: succeededOrFailed()
+
+  - task: PublishPipelineArtifact@1
+    displayName: Store conda build artifacts
+    condition: not(eq(variables.BLD_ARTIFACT_PATH, ''))
+    inputs:
+      targetPath: $(BLD_ARTIFACT_PATH)
+      artifactName: $(BLD_ARTIFACT_NAME)
+
+  - task: PublishPipelineArtifact@1
+    displayName: Store conda build environment artifacts
+    condition: not(eq(variables.ENV_ARTIFACT_PATH, ''))
+    inputs:
+      targetPath: $(ENV_ARTIFACT_PATH)
+      artifactName: $(ENV_ARTIFACT_NAME)

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -1,0 +1,82 @@
+# This file was generated automatically from conda-smithy. To update this configuration,
+# update the conda-forge.yml and/or the recipe/meta.yaml.
+# -*- mode: yaml -*-
+
+jobs:
+- job: win
+  pool:
+    vmImage: windows-2019
+  strategy:
+    matrix:
+      win_64_:
+        CONFIG: win_64_
+        UPLOAD_PACKAGES: 'True'
+  timeoutInMinutes: 360
+  variables:
+    CONDA_BLD_PATH: D:\\bld\\
+
+  steps:
+    - task: PythonScript@0
+      displayName: 'Download Miniforge'
+      inputs:
+        scriptSource: inline
+        script: |
+          import urllib.request
+          url = 'https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Windows-x86_64.exe'
+          path = r"$(Build.ArtifactStagingDirectory)/Miniforge.exe"
+          urllib.request.urlretrieve(url, path)
+
+    - script: |
+        start /wait "" %BUILD_ARTIFACTSTAGINGDIRECTORY%\Miniforge.exe /InstallationType=JustMe /RegisterPython=0 /S /D=C:\Miniforge
+      displayName: Install Miniforge
+
+    - powershell: Write-Host "##vso[task.prependpath]C:\Miniforge\Scripts"
+      displayName: Add conda to PATH
+
+    - script: |
+        call activate base
+        mamba.exe install 'python=3.9' conda-build conda pip boa 'conda-forge-ci-setup=3' -c conda-forge --strict-channel-priority --yes
+      displayName: Install conda-build
+
+    - script: set PYTHONUNBUFFERED=1
+      displayName: Set PYTHONUNBUFFERED
+
+    # Configure the VM
+    - script: |
+        call activate base
+        setup_conda_rc .\ ".\recipe" .\.ci_support\%CONFIG%.yaml
+      displayName: conda-forge CI setup
+
+    # Configure the VM.
+    - script: |
+        set "CI=azure"
+        call activate base
+        run_conda_forge_build_setup
+      displayName: conda-forge build setup
+
+    - script: |
+        call activate base
+        if EXIST LICENSE.txt (
+          copy LICENSE.txt "recipe\\recipe-scripts-license.txt"
+        )
+        conda.exe mambabuild "recipe" -m .ci_support\%CONFIG%.yaml --suppress-variables
+      displayName: Build recipe
+      env:
+        PYTHONUNBUFFERED: 1
+    - script: |
+        set "FEEDSTOCK_NAME=%BUILD_REPOSITORY_NAME:*/=%"
+        call activate base
+        validate_recipe_outputs "%FEEDSTOCK_NAME%"
+      displayName: Validate Recipe Outputs
+
+    - script: |
+        set "GIT_BRANCH=%BUILD_SOURCEBRANCHNAME%"
+        set "FEEDSTOCK_NAME=%BUILD_REPOSITORY_NAME:*/=%"
+        call activate base
+        upload_package --validate --feedstock-name="%FEEDSTOCK_NAME%" .\ ".\recipe" .ci_support\%CONFIG%.yaml
+      displayName: Upload package
+      env:
+        BINSTAR_TOKEN: $(BINSTAR_TOKEN)
+        FEEDSTOCK_TOKEN: $(FEEDSTOCK_TOKEN)
+        STAGING_BINSTAR_TOKEN: $(STAGING_BINSTAR_TOKEN)
+      condition: and(succeeded(), not(eq(variables['UPLOAD_PACKAGES'], 'False')), not(eq(variables['Build.Reason'], 'PullRequest')))

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -11,6 +11,7 @@ jobs:
       win_64_:
         CONFIG: win_64_
         UPLOAD_PACKAGES: 'True'
+        SHORT_CONFIG: win_64_
   timeoutInMinutes: 360
   variables:
     CONDA_BLD_PATH: D:\\bld\\
@@ -63,6 +64,33 @@ jobs:
       displayName: Build recipe
       env:
         PYTHONUNBUFFERED: 1
+    - script: |
+        set CI=azure
+        set CI_RUN_ID=$(build.BuildNumber).$(system.JobAttempt)
+        set FEEDSTOCK_NAME=$(build.Repository.Name)
+        set ARTIFACT_STAGING_DIR=$(Build.ArtifactStagingDirectory)
+        set CONDA_BLD_DIR=$(CONDA_BLD_PATH)
+        set BLD_ARTIFACT_PREFIX=conda_artifacts
+        if "%AGENT_JOBSTATUS%" == "Failed" (
+            set ENV_ARTIFACT_PREFIX=conda_envs
+        )
+        call ".scripts\create_conda_build_artifacts.bat"
+      displayName: Prepare conda build artifacts
+      condition: succeededOrFailed()
+
+    - task: PublishPipelineArtifact@1
+      displayName: Store conda build artifacts
+      condition: not(eq(variables.BLD_ARTIFACT_PATH, ''))
+      inputs:
+        targetPath: $(BLD_ARTIFACT_PATH)
+        artifactName: $(BLD_ARTIFACT_NAME)
+
+    - task: PublishPipelineArtifact@1
+      displayName: Store conda build environment artifacts
+      condition: not(eq(variables.ENV_ARTIFACT_PATH, ''))
+      inputs:
+        targetPath: $(ENV_ARTIFACT_PATH)
+        artifactName: $(ENV_ARTIFACT_NAME)
     - script: |
         set "FEEDSTOCK_NAME=%BUILD_REPOSITORY_NAME:*/=%"
         call activate base

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -1,10 +1,6 @@
-cdt_name:
-- cos6
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
 noarch_platform:
-- unix
+- win

--- a/.scripts/create_conda_build_artifacts.bat
+++ b/.scripts/create_conda_build_artifacts.bat
@@ -1,0 +1,80 @@
+setlocal enableextensions enabledelayedexpansion
+
+rem INPUTS (environment variables that need to be set before calling this script):
+rem
+rem CI (azure/github_actions/UNSET)
+rem CI_RUN_ID (unique identifier for the CI job run)
+rem FEEDSTOCK_NAME
+rem CONFIG (build matrix configuration string)
+rem SHORT_CONFIG (uniquely-shortened configuration string)
+rem CONDA_BLD_DIR (path to the conda-bld directory)
+rem ARTIFACT_STAGING_DIR (use working directory if unset)
+rem BLD_ARTIFACT_PREFIX (prefix for the conda build artifact name, skip if unset)
+rem ENV_ARTIFACT_PREFIX (prefix for the conda build environments artifact name, skip if unset)
+
+rem OUTPUTS
+rem
+rem BLD_ARTIFACT_NAME
+rem BLD_ARTIFACT_PATH
+rem ENV_ARTIFACT_NAME
+rem ENV_ARTIFACT_PATH
+
+rem Check that the conda-build directory exists
+if not exist %CONDA_BLD_DIR% (
+    echo conda-build directory does not exist
+    exit 1
+)
+
+if not defined ARTIFACT_STAGING_DIR (
+    rem Set staging dir to the working dir
+    set ARTIFACT_STAGING_DIR=%cd%
+)
+
+rem Set a unique ID for the artifact(s), specialized for this particular job run
+set ARTIFACT_UNIQUE_ID=%CI_RUN_ID%_%CONFIG%
+if not "%ARTIFACT_UNIQUE_ID%" == "%ARTIFACT_UNIQUE_ID:~0,80%" (
+    set ARTIFACT_UNIQUE_ID=%CI_RUN_ID%_%SHORT_CONFIG%
+)
+
+rem Set a descriptive ID for the archive(s), specialized for this particular job run
+set ARCHIVE_UNIQUE_ID=%CI_RUN_ID%_%CONFIG%
+
+rem Make the build artifact zip
+if defined BLD_ARTIFACT_PREFIX (
+    set BLD_ARTIFACT_NAME=%BLD_ARTIFACT_PREFIX%_%ARTIFACT_UNIQUE_ID%
+    echo BLD_ARTIFACT_NAME: !BLD_ARTIFACT_NAME!
+
+    set "BLD_ARTIFACT_PATH=%ARTIFACT_STAGING_DIR%\%FEEDSTOCK_NAME%_%BLD_ARTIFACT_PREFIX%_%ARCHIVE_UNIQUE_ID%.zip"
+    7z a "!BLD_ARTIFACT_PATH!" "%CONDA_BLD_DIR%" -xr^^!.git/ -xr^^!_*_env*/ -xr^^!*_cache/ -bb
+    if errorlevel 1 exit 1
+    echo BLD_ARTIFACT_PATH: !BLD_ARTIFACT_PATH!
+
+    if "%CI%" == "azure" (
+        echo ##vso[task.setVariable variable=BLD_ARTIFACT_NAME]!BLD_ARTIFACT_NAME!
+        echo ##vso[task.setVariable variable=BLD_ARTIFACT_PATH]!BLD_ARTIFACT_PATH!
+    )
+    if "%CI%" == "github_actions" (
+        echo ::set-output name=BLD_ARTIFACT_NAME::!BLD_ARTIFACT_NAME!
+        echo ::set-output name=BLD_ARTIFACT_PATH::!BLD_ARTIFACT_PATH!
+    )
+)
+
+rem Make the environments artifact zip
+if defined ENV_ARTIFACT_PREFIX (
+    set ENV_ARTIFACT_NAME=!ENV_ARTIFACT_PREFIX!_%ARTIFACT_UNIQUE_ID%
+    echo ENV_ARTIFACT_NAME: !ENV_ARTIFACT_NAME!
+
+    set "ENV_ARTIFACT_PATH=%ARTIFACT_STAGING_DIR%\%FEEDSTOCK_NAME%_%ENV_ARTIFACT_PREFIX%_%ARCHIVE_UNIQUE_ID%.zip"
+    7z a "!ENV_ARTIFACT_PATH!" -r "%CONDA_BLD_DIR%"/_*_env*/ -bb
+    if errorlevel 1 exit 1
+    echo ENV_ARTIFACT_PATH: !ENV_ARTIFACT_PATH!
+
+    if "%CI%" == "azure" (
+        echo ##vso[task.setVariable variable=ENV_ARTIFACT_NAME]!ENV_ARTIFACT_NAME!
+        echo ##vso[task.setVariable variable=ENV_ARTIFACT_PATH]!ENV_ARTIFACT_PATH!
+    )
+    if "%CI%" == "github_actions" (
+        echo ::set-output name=ENV_ARTIFACT_NAME::!ENV_ARTIFACT_NAME!
+        echo ::set-output name=ENV_ARTIFACT_PATH::!ENV_ARTIFACT_PATH!
+    )
+)

--- a/.scripts/create_conda_build_artifacts.sh
+++ b/.scripts/create_conda_build_artifacts.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+
+# INPUTS (environment variables that need to be set before calling this script):
+#
+# CI (azure/github_actions/UNSET)
+# CI_RUN_ID (unique identifier for the CI job run)
+# FEEDSTOCK_NAME
+# CONFIG (build matrix configuration string)
+# SHORT_CONFIG (uniquely-shortened configuration string)
+# CONDA_BLD_DIR (path to the conda-bld directory)
+# ARTIFACT_STAGING_DIR (use working directory if unset)
+# BLD_ARTIFACT_PREFIX (prefix for the conda build artifact name, skip if unset)
+# ENV_ARTIFACT_PREFIX (prefix for the conda build environments artifact name, skip if unset)
+
+# OUTPUTS
+#
+# BLD_ARTIFACT_NAME
+# BLD_ARTIFACT_PATH
+# ENV_ARTIFACT_NAME
+# ENV_ARTIFACT_PATH
+
+source .scripts/logging_utils.sh
+
+# DON'T do set -x, because it results in double echo-ing pipeline commands
+# and that might end up inserting extraneous quotation marks in output variables
+set -e
+
+# Check that the conda-build directory exists
+if [ ! -d "$CONDA_BLD_DIR" ]; then
+    echo "conda-build directory does not exist"
+    exit 1
+fi
+
+# Set staging dir to the working dir, in Windows style if applicable
+if [[ -z "${ARTIFACT_STAGING_DIR}" ]]; then
+    if pwd -W; then
+        ARTIFACT_STAGING_DIR=$(pwd -W)
+    else
+        ARTIFACT_STAGING_DIR=$PWD
+    fi
+fi
+echo "ARTIFACT_STAGING_DIR: $ARTIFACT_STAGING_DIR"
+
+FEEDSTOCK_ROOT=$(cd "$(dirname "$0")/.."; pwd;)
+if [ -z ${FEEDSTOCK_NAME} ]; then
+    export FEEDSTOCK_NAME=$(basename ${FEEDSTOCK_ROOT})
+fi
+
+# Set a unique ID for the artifact(s), specialized for this particular job run
+ARTIFACT_UNIQUE_ID="${CI_RUN_ID}_${CONFIG}"
+if [[ ${#ARTIFACT_UNIQUE_ID} -gt 80 ]]; then
+    ARTIFACT_UNIQUE_ID="${CI_RUN_ID}_${SHORT_CONFIG}"
+fi
+echo "ARTIFACT_UNIQUE_ID: $ARTIFACT_UNIQUE_ID"
+
+# Set a descriptive ID for the archive(s), specialized for this particular job run
+ARCHIVE_UNIQUE_ID="${CI_RUN_ID}_${CONFIG}"
+
+# Make the build artifact zip
+if [[ ! -z "$BLD_ARTIFACT_PREFIX" ]]; then
+    export BLD_ARTIFACT_NAME="${BLD_ARTIFACT_PREFIX}_${ARTIFACT_UNIQUE_ID}"
+    export BLD_ARTIFACT_PATH="${ARTIFACT_STAGING_DIR}/${FEEDSTOCK_NAME}_${BLD_ARTIFACT_PREFIX}_${ARCHIVE_UNIQUE_ID}.zip"
+
+    ( startgroup "Archive conda build directory" ) 2> /dev/null
+
+    # Try 7z and fall back to zip if it fails (for cross-platform use)
+    if ! 7z a "$BLD_ARTIFACT_PATH" "$CONDA_BLD_DIR" '-xr!.git/' '-xr!_*_env*/' '-xr!*_cache/' -bb; then
+        pushd "$CONDA_BLD_DIR"
+        zip -r -y -T "$BLD_ARTIFACT_PATH" . -x '*.git/*' '*_*_env*/*' '*_cache/*'
+        popd
+    fi
+
+    ( endgroup "Archive conda build directory" ) 2> /dev/null
+
+    echo "BLD_ARTIFACT_NAME: $BLD_ARTIFACT_NAME"
+    echo "BLD_ARTIFACT_PATH: $BLD_ARTIFACT_PATH"
+
+    if [[ "$CI" == "azure" ]]; then
+        echo "##vso[task.setVariable variable=BLD_ARTIFACT_NAME]$BLD_ARTIFACT_NAME"
+        echo "##vso[task.setVariable variable=BLD_ARTIFACT_PATH]$BLD_ARTIFACT_PATH"
+    elif [[ "$CI" == "github_actions" ]]; then
+        echo "::set-output name=BLD_ARTIFACT_NAME::$BLD_ARTIFACT_NAME"
+        echo "::set-output name=BLD_ARTIFACT_PATH::$BLD_ARTIFACT_PATH"
+    fi
+fi
+
+# Make the environments artifact zip
+if [[ ! -z "$ENV_ARTIFACT_PREFIX" ]]; then
+    export ENV_ARTIFACT_NAME="${ENV_ARTIFACT_PREFIX}_${ARTIFACT_UNIQUE_ID}"
+    export ENV_ARTIFACT_PATH="${ARTIFACT_STAGING_DIR}/${FEEDSTOCK_NAME}_${ENV_ARTIFACT_PREFIX}_${ARCHIVE_UNIQUE_ID}.zip"
+
+    ( startgroup "Archive conda build environments" ) 2> /dev/null
+
+    # Try 7z and fall back to zip if it fails (for cross-platform use)
+    if ! 7z a "$ENV_ARTIFACT_PATH" -r "$CONDA_BLD_DIR"/'_*_env*/' -bb; then
+        pushd "$CONDA_BLD_DIR"
+        zip -r -y -T "$ENV_ARTIFACT_PATH" . -i '*_*_env*/*'
+        popd
+    fi
+
+    ( endgroup "Archive conda build environments" ) 2> /dev/null
+
+    echo "ENV_ARTIFACT_NAME: $ENV_ARTIFACT_NAME"
+    echo "ENV_ARTIFACT_PATH: $ENV_ARTIFACT_PATH"
+
+    if [[ "$CI" == "azure" ]]; then
+        echo "##vso[task.setVariable variable=ENV_ARTIFACT_NAME]$ENV_ARTIFACT_NAME"
+        echo "##vso[task.setVariable variable=ENV_ARTIFACT_PATH]$ENV_ARTIFACT_PATH"
+    elif [[ "$CI" == "github_actions" ]]; then
+        echo "::set-output name=ENV_ARTIFACT_NAME::$ENV_ARTIFACT_NAME"
+        echo "::set-output name=ENV_ARTIFACT_PATH::$ENV_ARTIFACT_PATH"
+    fi
+fi

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,3 +4,4 @@
 
 jobs:
   - template: ./.azure-pipelines/azure-pipelines-linux.yml
+  - template: ./.azure-pipelines/azure-pipelines-win.yml

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,13 +1,15 @@
-provider:
-  linux_aarch64: default
-  linux_ppc64le: default
-  win: azure
-conda_forge_output_validation: true
+azure:
+  store_build_artifacts: true
 bot:
   automerge: true
+conda_forge_output_validation: true
 github:
   branch_name: main
   tooling_branch_name: main
 noarch_platforms:
   - linux_64
   - win_64
+provider:
+  linux_aarch64: default
+  linux_ppc64le: default
+  win: azure

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,7 +1,13 @@
-provider: {linux_aarch64: default, linux_ppc64le: default, win: azure}
+provider:
+  linux_aarch64: default
+  linux_ppc64le: default
+  win: azure
 conda_forge_output_validation: true
 bot:
   automerge: true
 github:
   branch_name: main
   tooling_branch_name: main
+noarch_platforms:
+  - linux_64
+  - win_64

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,3 @@
+noarch_platform:
+  - unix  # [linux]
+  - win  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -109,7 +109,7 @@ outputs:
         - {{ pin_subpackage("jupyterhub-base", exact=True) }}
         - configurable-http-proxy >=4
         - nodejs >=12
-        - psutil  # undeclared extra, used preferentially for logging
+        - psutil >=5.6.5  # undeclared extra, used preferentially for logging
         - pycurl  # undeclared extra, used preferentially for performance
         - python >=3.7
     test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,7 +44,7 @@ outputs:
         {% if noarch_platform == "unix" %}
         - pamela
         {% else %}
-        - psutil >=5.6.5
+        - psutil
         {% endif %}
         - prometheus_client >=0.4.0
         - python >=3.7
@@ -53,6 +53,8 @@ outputs:
         - sqlalchemy >=1.1
         - tornado >=5.1
         - traitlets >=4.3.2
+      run_constrained:
+        - psutil >=5.6.5
 
     test:
       requires:
@@ -109,7 +111,7 @@ outputs:
         - {{ pin_subpackage("jupyterhub-base", exact=True) }}
         - configurable-http-proxy >=4
         - nodejs >=12
-        - psutil >=5.6.5  # undeclared extra, used preferentially for logging
+        - psutil  # undeclared extra, used preferentially for logging
         - pycurl  # undeclared extra, used preferentially for performance
         - python >=3.7
     test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,7 @@ outputs:
         - packaging
         {% if noarch_platform == "unix" %}
         - pamela
-        {% else }
+        {% else %}
         - psutil >=5.6.5
         {% endif %}
         - prometheus_client >=0.4.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,7 @@ outputs:
         - alembic >=1.4
         - async_generator >=1.9
         - certipy >=0.1.2
-        - importlib_metadata >=3.6  # not actually required for Python >=3.10
+        - importlib-metadata >=3.6  # not actually required for Python >=3.10
         - jinja2 >=2.11.0
         - jupyter_telemetry >=0.1.0
         - oauthlib >=3.0
@@ -122,7 +122,7 @@ outputs:
       commands:
         - pip check
         - jupyterhub --help-all
-        - configurable-http-proxy --help
+        - configurable-http-proxy --help  # [not win]
 
 about:
   home: https://github.com/jupyterhub/jupyterhub

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,6 +32,7 @@ outputs:
         - python >=3.7
         - pip
       run:
+        - __{{ noarch_platform }}
         - alembic >=1.4
         - async_generator >=1.9
         - certipy >=0.1.2
@@ -84,6 +85,7 @@ outputs:
       host:
         - python >=3.7
       run:
+        - __{{ noarch_platform }}
         - {{ pin_subpackage("jupyterhub-base", exact=True) }}
         - jupyterlab >=3.1
         - python >=3.7
@@ -103,6 +105,7 @@ outputs:
       host:
         - python >=3.7
       run:
+        - __{{ noarch_platform }}
         - {{ pin_subpackage("jupyterhub-base", exact=True) }}
         - configurable-http-proxy >=4
         - nodejs >=12

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,11 @@ outputs:
         - jupyter_telemetry >=0.1.0
         - oauthlib >=3.0
         - packaging
+        {% if noarch_platform == "unix" %}
         - pamela
+        {% else }
+        - psutil >=5.6.5
+        {% endif %}
         - prometheus_client >=0.4.0
         - python >=3.7
         - python-dateutil
@@ -61,10 +65,17 @@ outputs:
       commands:
         - pip check
         - jupyterhub --help-all
+        {% if noarch_platform == "unix" %}
         - test -f $PREFIX/share/jupyterhub/templates/page.html
         - test -f $PREFIX/share/jupyterhub/static/components/jquery/dist/jquery.min.js
         - test -f $PREFIX/share/jupyterhub/static/css/style.min.css
         - test -f $PREFIX/share/jupyterhub/static/js/home.js
+        {% else %}
+        - dir %PREFIX%\share\jupyterhub\templates\page.html || exit 1
+        - dir %PREFIX%\share\jupyterhub\static\components\jquery\dist\jquery.min.js || exit 1
+        - dir %PREFIX%\share\jupyterhub\static\css\style.min.css || exit 1
+        - dir %PREFIX%\share\jupyterhub\static\js\home.js || exit 1
+        {% endif %}
 
   - name: jupyterhub-singleuser
     build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 05cdfebd800cf3e55566fb5b61110c5f64fed8ca3c56ef0142290baffbc7fb69
 
 build:
-  number: 0
+  number: 1
   noarch: python
 
 requirements:
@@ -42,8 +42,6 @@ outputs:
         - packaging
         - pamela
         - prometheus_client >=0.4.0
-        - psutil  # undeclared extra, used preferentially for logging
-        - pycurl  # undeclared extra, used preferentially for performance
         - python >=3.7
         - python-dateutil
         - requests
@@ -97,6 +95,8 @@ outputs:
         - {{ pin_subpackage("jupyterhub-base", exact=True) }}
         - configurable-http-proxy >=4
         - nodejs >=12
+        - psutil  # undeclared extra, used preferentially for logging
+        - pycurl  # undeclared extra, used preferentially for performance
         - python >=3.7
     test:
       requires:


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Notes:
- [x] exploring ways to get to interactive testing of the stack on binder python3.11 sooner rather than later
  - https://gist.github.com/bollwyvl/5f3efbca22eaafdd07ca2c87a6ac6e31
- [x] add `pycurl` and `psutil` to the `jupyterhub` metapackage
  - it doesn't appear these benefit the `single-user` experience, but almost certainly do the full spawner+X setup
- [x] add dedicated windows build with hard dep on `psutil`
- [x] add `__win` and `__unix` metapackages with `linux64` and `win64` builds 
- [x] make `pamela` only on `__unix` 
  - can't be removed and keep `pip check`
- [x] move `psutil >=5.6.5` to run-constrained, required on `win`
- [x] skip `configurable-http-proxy` check on windows
  -  might need investigation over there, e.g. `%SCRIPTS%\configurable-http-proxy.cmd`
- [x] add (failing) build artifact uploading in azure 
- [x] clean up, sort `conda-forge.yml` 